### PR TITLE
Question 17, Exam 1

### DIFF
--- a/practice-exam/practice-exam-1.md
+++ b/practice-exam/practice-exam-1.md
@@ -169,7 +169,7 @@ If this practice exam has been helpful to you please share it with others and re
       Correct answer: D
     </details>
 
-17. What do you gain from setting up consolidated billing for five different AWS accounts under another master account?
+17. What do you gain from setting up consolidated billing for five different AWS accounts?
     - A. AWS services’ costs will be reduced to half the original price.
     - B. The consolidated billing feature is just for organizational purpose.
     - C. Each AWS account gets volume discounts.


### PR DESCRIPTION
Remove "under another master account"

There may not be a significant benefit to using another account instead of one of the five AWS accounts when setting up consolidated billing. Adding another account may add unnecessary complexity to the billing process, right?