### PR TITLE
Update practice-exam-2.md Fix 48 Question Change Answer A To C

### DIFF
--- a/practice-exam/practice-exam-2.md
+++ b/practice-exam/practice-exam-2.md
@@ -493,7 +493,7 @@ layout: exam
     - D. AWS Professional Services.
 
     <details markdown=1><summary markdown='span'>Answer</summary>
-      Correct answer: A
+      Correct answer: C
     </details>
 
 49. What is the AWS serverless service that allows you to run your applications without any administrative burden?


### PR DESCRIPTION
fix 48 (answer A to C)

The original answer selected "APN Consulting Partners" (A), which refers to service-based companies that provide hands-on architectural guidance and consulting services. However, the question states that the company has "created a solution that helps AWS customers improve their architectures," indicating a **software-based offering** rather than a professional service.

The more appropriate AWS program for companies that **build and deliver technology products** on AWS is "APN Technology Partners" (C). These partners create SaaS, platform tools, or packaged solutions that integrate with AWS and help customers improve their cloud architecture indirectly via those tools.

Therefore, this commit corrects the answer to reflect that distinction.

I also validated with ChatGPT to corroborated the answer.