### PR TITLE
Fix: Practice exam 4 - Q1. Answer is collected from AWS official latest document.

### DIFF
--- a/practice-exam/practice-exam-4.md
+++ b/practice-exam/practice-exam-4.md
@@ -12,7 +12,7 @@ layout: exam
     - E. AWS Data Pipeline.
 
     <details markdown=1><summary markdown='span'>Answer</summary>
-      Correct answer: A, B
+      Correct answer: B, D
     </details>
 
 2. Which of the following AWS services scale automatically without your intervention? (Choose TWO)


### PR DESCRIPTION
**Question 1:** A developer needs to set up an SSL security certificate for a client's eCommerce website in order to use the HTTPS protocol. Which of the following AWS services can be used to deploy the required SSL server certificates? (Choose TWO)

A. Amazon Route 53.
B. AWS ACM.
C. AWS Directory Service.
D. AWS Identity & Access Management.
E. AWS Data Pipeline.

**Current Ans: A, B**
**Revised and Correct Ans: B, D**

**### Related Link:**  https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html
### Related Issue
Fixes #298

### Explanation 
**B. AWS Certificate Manager (ACM):**
ACM is the primary AWS service used to provision, manage, and deploy SSL/TLS certificates for use with AWS services like Elastic Load Balancers, CloudFront distributions, and API Gateway.

**D. AWS Identity & Access Management (IAM):**
IAM can also store and deploy SSL/TLS certificates, particularly when you're using them with services like EC2 instances running a web server or Classic Load Balancers.

### Incorrect Options
**A. Amazon Route 53:**
This is a DNS web service. It does not manage SSL certificates.

**C. AWS Directory Service:**
This is used for integrating AWS resources with Microsoft Active Directory, not for SSL certificates.

**E. AWS Data Pipeline:**
This service is for data workflow orchestration—not related to certificates.

`ACM is the preferred tool to provision, manage, and deploy your server certificates. But ACM is not supported to all regions. AWS suggests to use IAM as a certificate manager only when you must support HTTPS connections in a Region that is not supported by ACM.`