### PR TITLE
Replace duplicate AWS Artifact question with improved wording

### DIFF
--- a/practice-exam/practice-exam-9.md
+++ b/practice-exam/practice-exam-9.md
@@ -340,14 +340,14 @@ layout: exam
       Correct answer: B
     </details>
 
-34. Where can AWS compliance and certification reports be downloaded?
-    - A. AWS Artifact.
-    - B. AWS Concierge.
-    - C. AWS Certificate Manager.
-    - D. AWS Trusted Advisor.
+34. Which AWS service provides on-demand access to AWS security and compliance documentation?
+    - A. AWS Certificate Manager.
+    - B. AWS Trusted Advisor.
+    - C. AWS Artifact.
+    - D. AWS Organizations.
 
     <details markdown=1><summary markdown='span'>Answer</summary>
-      Correct answer: A
+      Correct answer: C
     </details>
 
 35. The financial benefits of using AWS are: (Select TWO)


### PR DESCRIPTION
### Summary
This PR replaces a duplicate question about AWS Artifact in the quiz repository. 
The original quiz had two questions (questions 34 and 46) that were nearly identical in wording and tested the same concept (downloading AWS compliance and certification reports). 
To improve variety and avoid redundancy, question 34 has been updated with new wording and shuffled answer order.

### Changes
- Replaced duplicate AWS Artifact question with: "Which AWS service provides on-demand access to AWS security and compliance documentation?"
- Shuffled answer order to place AWS Artifact as option C.
- Maintained consistent formatting with `<details>` for the answer section.

### Why
This improves question diversity and prevents repetition in quizzes, while continuing to test the candidate's knowledge of AWS Artifact.
