### PR TITLE
Update correct answer for question in practice exam 4/1

### DIFF
--- a/practice-exam/practice-exam-4.md
+++ b/practice-exam/practice-exam-4.md
@@ -12,7 +12,7 @@ layout: exam
     - E. AWS Data Pipeline.
 
     <details markdown=1><summary markdown='span'>Answer</summary>
-      Correct answer: A, B
+      Correct answer: B, D
     </details>
 
 2. Which of the following AWS services scale automatically without your intervention? (Choose TWO)


### PR DESCRIPTION
Correct answers: B, D

B. AWS ACM (AWS Certificate Manager)
Provides, manages, and deploys SSL/TLS certificates for AWS services like:

Load Balancers
CloudFront
API Gateway

⇒ This is the main service for SSL certificates.

D. AWS Identity & Access Management (IAM)
Can also manage SSL certificates for certain use cases (especially legacy / EC2-based setups with ELB).

Why A is wrong
Amazon Route 53 is a DNS service
It routes traffic to domains but does NOT issue or deploy SSL certificates